### PR TITLE
Allow users to import the module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .eslintcache
 README.md.html
+*.js

--- a/crosscode-ccloader-all.d.ts
+++ b/crosscode-ccloader-all.d.ts
@@ -3,3 +3,5 @@ import './nw';
 import './modloader';
 import './modloader-stdlib';
 import './ccloader-ui';
+
+export * from './crosscode';

--- a/crosscode-nw.d.ts
+++ b/crosscode-nw.d.ts
@@ -2,3 +2,5 @@
 
 import './nw';
 import './crosscode';
+
+export * from './crosscode';

--- a/crosscode.d.ts
+++ b/crosscode.d.ts
@@ -8,3 +8,7 @@ import './impact-class-system-correct';
 import './impact-core';
 import './crosscode-external-scripts';
 import './modules/__all__';
+
+//Convert namespaces to variables
+export declare const ig: { [key in keyof typeof window.ig]: typeof window.ig[key] };
+export declare const sc: { [key in keyof typeof window.sc]: typeof window.sc[key] };

--- a/index-crosscode-ccloader-all.ts
+++ b/index-crosscode-ccloader-all.ts
@@ -1,0 +1,4 @@
+/* eslint-disable node/no-missing-import */
+import type * as _types from './crosscode-ccloader-all'
+
+export const { ig, sc } = window;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,19 @@
     "check": "tsc --noEmit",
     "watch": "tsc --noEmit --watch",
     "lint": "eslint . --ext .ts",
-    "check-fmt": "prettier --check '**/*.ts'"
+    "check-fmt": "prettier --check '**/*.ts'",
+    "prepare": "tsc"
+  },
+  "exports": {
+    ".": "./index-crosscode-ccloader-all.js",
+    "./crosscode-ccloader-all.js": "./index-crosscode-ccloader-all.js"
+  },
+  "types": "crosscode-ccloader-all.d.ts",
+  "typesVersions": {
+      "*": {
+          "crosscode-ccloader-all.js": [
+              "./crosscode-ccloader-all.d.ts"
+          ]
+      }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "include": ["*.d.ts", "modules", "modloader", "file-types", "modloader-stdlib", "mods"],
+  "include": ["*.ts", "modules", "modloader", "file-types", "modloader-stdlib", "mods"],
   "compilerOptions": {
+    "module": "ES2015",
     "lib": ["ES6"],
-    "noEmit": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true
   }


### PR DESCRIPTION
This PR allows a user to import the types using 
```ts
import { ig, sc } from 'ultimate-crosscode-typedefs';
```

This also means that you no longer need to modify your `tsconfig.json` when installing `ultimate-crosscode-typedefs`.